### PR TITLE
Settings modal

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,8 +1,10 @@
 <main id="container">
   <header>
     <h1>TomatoTimer</h1>
-    <button id="settingsBtn">Settings</button>
+    <button 
+      (click)="openModal('settings-modal')" id="settingsBtn">Settings</button>
   </header>
+  <app-settings-page id="settings-modal"></app-settings-page>
   <timer-taskbar></timer-taskbar>
   <timer-display></timer-display>
   <timer-controls></timer-controls>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,7 +53,6 @@ export class AppComponent {
   }
 
   openModal(id: string) {
-    console.log(id);
     this.modalService.open(id);
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { KeyValuePipe } from '@angular/common';
 import { Component, HostListener } from '@angular/core';
 import { TimerService } from './timer.service';
+import { ModalService } from './modal.service';
 export enum KEY {
   SPACE = ' ',
   ALT = 'Alt',
@@ -18,7 +19,7 @@ export class AppComponent {
 
   title = 'pomodoro-timer';
 
-  constructor(private timerService: TimerService) {}
+  constructor(private timerService: TimerService, private modalService: ModalService) {}
 
   @HostListener('window:keydown', ['$event']) onKeyDown(e): void {
     if (e.key === KEY.SPACE) {
@@ -49,5 +50,14 @@ export class AppComponent {
     else {
       this.timerService.startTimer();
     }
+  }
+
+  openModal(id: string) {
+    console.log(id);
+    this.modalService.open(id);
+  }
+
+  closeModal(id: string) {
+    this.modalService.close(id);
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { TimerTaskbarComponent } from './timer-taskbar/timer-taskbar.component';
 import { TimerDisplayComponent } from './timer-display/timer-display.component';
 import { TimerControlsComponent } from './timer-controls/timer-controls.component';
 import { InfoComponent } from './info/info.component';
+import { SettingsPageComponent } from './settings-page/settings-page.component';
 
 @NgModule({
   declarations: [
@@ -13,7 +14,8 @@ import { InfoComponent } from './info/info.component';
     TimerTaskbarComponent,
     TimerDisplayComponent,
     TimerControlsComponent,
-    InfoComponent
+    InfoComponent,
+    SettingsPageComponent
   ],
   imports: [
     BrowserModule

--- a/src/app/modal.service.spec.ts
+++ b/src/app/modal.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ModalService } from './modal.service';
+
+describe('ModalService', () => {
+  let service: ModalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ModalService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/modal.service.ts
+++ b/src/app/modal.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ModalService {
+
+  constructor() { }
+}

--- a/src/app/modal.service.ts
+++ b/src/app/modal.service.ts
@@ -4,6 +4,25 @@ import { Injectable } from '@angular/core';
   providedIn: 'root'
 })
 export class ModalService {
-
+  private _modals: any[] = [];
   constructor() { }
+
+  add(modal: any) {
+    this._modals.push(modal);
+  }
+
+  remove(id: string) {
+    this._modals = this._modals.filter(x => x.id != id);
+  }
+
+  open(id: string) {
+    const modal = this._modals.find(x => x.id === id);
+    modal.open();
+  }
+
+  close(id: string) {
+    const modal = this._modals.find(x => x.id === id);
+    modal.close();
+  }
+
 }

--- a/src/app/settings-page/settings-page.component.css
+++ b/src/app/settings-page/settings-page.component.css
@@ -25,8 +25,13 @@ body.settings-page-open {
 div#settings-option-container {
     background-color: #FFF;
     width: 50%;
-    height: 50%;
+    height: 60%;
     display: flex;
     flex-direction: column;
     justify-content: space-around;
+}
+
+select {
+    width: 100%;
+    height: 75px;
 }

--- a/src/app/settings-page/settings-page.component.css
+++ b/src/app/settings-page/settings-page.component.css
@@ -1,0 +1,16 @@
+div.settings-page {
+    display: none;
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 1000;
+    overflow: auto;
+    background-color: #000;
+    opacity: 0.75;
+}
+
+body.settings-page-open {
+    overflow: hidden;
+}

--- a/src/app/settings-page/settings-page.component.css
+++ b/src/app/settings-page/settings-page.component.css
@@ -5,16 +5,28 @@
 
 div.settings-container{
     position: fixed;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
     top: 0;
     bottom: 0;
     left: 0;
     right: 0;
     z-index: 1000;
     overflow: auto;
-    background-color: #000;
-    opacity: 0.75;
+    background-color: rgba(0,0,0,0.45);
 }
 
 body.settings-page-open {
     overflow: hidden;
+}
+
+div#settings-option-container {
+    background-color: #FFF;
+    width: 50%;
+    height: 50%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
 }

--- a/src/app/settings-page/settings-page.component.css
+++ b/src/app/settings-page/settings-page.component.css
@@ -33,5 +33,6 @@ div#settings-option-container {
 
 select {
     width: 100%;
-    height: 75px;
+    min-width: 75px;
+    padding: 5px 0;
 }

--- a/src/app/settings-page/settings-page.component.css
+++ b/src/app/settings-page/settings-page.component.css
@@ -1,5 +1,9 @@
-div.settings-page {
+/* css stylings to default component display to none */
+#settings-modal {
     display: none;
+}
+
+div.settings-container{
     position: fixed;
     top: 0;
     bottom: 0;

--- a/src/app/settings-page/settings-page.component.html
+++ b/src/app/settings-page/settings-page.component.html
@@ -1,0 +1,1 @@
+<p>settings-page works!</p>

--- a/src/app/settings-page/settings-page.component.html
+++ b/src/app/settings-page/settings-page.component.html
@@ -14,12 +14,40 @@
         </div>
         <div id="sound-container">
             <h4>Select Sound</h4>
+            <select id="alertOption" size="5">
+                <option value="beep">Beep</option>
+                <option value="beep">Test</option>
+                <option value="beep">Test</option>
+                <option value="beep">Test</option>
+                <option value="beep">Test</option>
+            </select>
         </div>
              <div id="sound-container">
             <h4>Select Volume</h4>
+            <select id="volumeOption" size="5">
+                <option value="mute">mute</option>
+                <option value="twentyFivePercent">25%</option>
+                <option value="fiftyPercent">50%</option>
+                <option value="seventyFivePercent">75%</option>
+                <option value="fullVolume">100%</option>
+            </select>
         </div>
              <div id="sound-container">
             <h4>Set Custom Times (in minutes)</h4>
+            <div class="timerSettings">
+                <label for="pomodroTimerSettings">Pomodoro</label>
+                <input id="pomodoroTimerSettings" type="number" step="1" min="1">
+            </div>
+
+            <div class="timerSettings">
+                <label for="shortBreakSettings">Short Break</label>
+                <input id="shortBreakSettings" type="number" step="1" min="1">
+            </div>
+
+            <div class="timerSettings">
+                <label for="longBreakSettings">Long Break</label>
+                <input id="longBreakSettings" type="number" step="1" min="1">
+            </div>
         </div>
              <div id="sound-container">
             <button>Save</button>

--- a/src/app/settings-page/settings-page.component.html
+++ b/src/app/settings-page/settings-page.component.html
@@ -1,1 +1,2 @@
-<p>settings-page works!</p>
+<div class="settings-page">
+</div>

--- a/src/app/settings-page/settings-page.component.html
+++ b/src/app/settings-page/settings-page.component.html
@@ -1,1 +1,30 @@
-<div class="settings-container"></div>
+<div class="settings-container">
+    <div id="settings-option-container">
+        <h1>Options</h1>
+        <div id="preferences-container">
+            <h4>User Preferences</h4>
+            <input id="timerIndicatorOption" type="checkbox">
+            <label for="timerIndicatorOption">Timer indication in browser tab?</label>
+
+            <input id="browserNotificationOption" type="checkbox">
+            <label for="browserNotificationOption">Browser notifications?</label>
+
+            <input id="autoStartTimersOption" type="checkbox">
+            <label for="autoStartTimersOption">Auto start pomodoros and breaks?</label>
+        </div>
+        <div id="sound-container">
+            <h4>Select Sound</h4>
+        </div>
+             <div id="sound-container">
+            <h4>Select Volume</h4>
+        </div>
+             <div id="sound-container">
+            <h4>Set Custom Times (in minutes)</h4>
+        </div>
+             <div id="sound-container">
+            <button>Save</button>
+            <button>Reset</button>
+            <button>Sound Test</button>
+        </div>
+    </div>
+</div>

--- a/src/app/settings-page/settings-page.component.html
+++ b/src/app/settings-page/settings-page.component.html
@@ -1,2 +1,1 @@
-<div class="settings-page">
-</div>
+<div class="settings-container"></div>

--- a/src/app/settings-page/settings-page.component.spec.ts
+++ b/src/app/settings-page/settings-page.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SettingsPageComponent } from './settings-page.component';
+
+describe('SettingsPageComponent', () => {
+  let component: SettingsPageComponent;
+  let fixture: ComponentFixture<SettingsPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SettingsPageComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SettingsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/settings-page/settings-page.component.ts
+++ b/src/app/settings-page/settings-page.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-settings-page',
+  templateUrl: './settings-page.component.html',
+  styleUrls: ['./settings-page.component.css']
+})
+export class SettingsPageComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/settings-page/settings-page.component.ts
+++ b/src/app/settings-page/settings-page.component.ts
@@ -1,15 +1,53 @@
-import { Component, OnInit } from '@angular/core';
-
+import { Component, ElementRef, Input, OnInit, ViewEncapsulation, OnDestroy } from '@angular/core';
+import { ModalService } from '../modal.service';
 @Component({
   selector: 'app-settings-page',
   templateUrl: './settings-page.component.html',
-  styleUrls: ['./settings-page.component.css']
+  styleUrls: ['./settings-page.component.css'],
+  encapsulation: ViewEncapsulation.None
 })
-export class SettingsPageComponent implements OnInit {
-
-  constructor() { }
+export class SettingsPageComponent implements OnInit, OnDestroy {
+  @Input() id: string;
+  private element: any;
+  constructor(private modalService: ModalService, private el: ElementRef) {
+    this.element = el.nativeElement;
+  }
 
   ngOnInit(): void {
+    if (!this.id) {
+      console.error("Component using the modal service must have an ID");
+      return;
+    }
+
+
+    //Move element to the bottom of the page (before </body>) so it can
+    // be displayed above everything else.
+
+    document.body.appendChild(this.element);
+
+    this.element.addEventListener('click', el => {
+      if (el.target.className === 'app-settings-page') {
+        this.close();
+      }
+    });
+
+    // add this modal instance to the modal service so its accessible from controllers
+    this.modalService.add(this);
+  }
+
+  ngOnDestroy(): void {
+    this.modalService.remove(this.id);
+    this.element.remove();
+  }
+
+  open(): void {
+    this.element.style.display == 'block';
+    document.body.classList.add('settings-page-open');
+  }
+
+  close(): void {
+    this.element.style.display == 'none';
+    document.body.classList.remove('settings-page-open');
   }
 
 }

--- a/src/app/settings-page/settings-page.component.ts
+++ b/src/app/settings-page/settings-page.component.ts
@@ -37,7 +37,6 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
     // add this modal instance to the modal service so its accessible from controllers
     this.modalService.add(this);
 
-//    this.element.style.display = 'none';
   }
 
   ngOnDestroy(): void {

--- a/src/app/settings-page/settings-page.component.ts
+++ b/src/app/settings-page/settings-page.component.ts
@@ -9,6 +9,7 @@ import { ModalService } from '../modal.service';
 export class SettingsPageComponent implements OnInit, OnDestroy {
   @Input() id: string;
   private element: any;
+
   constructor(private modalService: ModalService, private el: ElementRef) {
     this.element = el.nativeElement;
   }
@@ -19,6 +20,8 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
       return;
     }
 
+    // Set the default display value to none
+    this.element.style.display = 'none';
 
     //Move element to the bottom of the page (before </body>) so it can
     // be displayed above everything else.
@@ -26,13 +29,15 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
     document.body.appendChild(this.element);
 
     this.element.addEventListener('click', el => {
-      if (el.target.className === 'app-settings-page') {
+      if (el.target.className === 'settings-container') {
         this.close();
       }
     });
 
     // add this modal instance to the modal service so its accessible from controllers
     this.modalService.add(this);
+
+//    this.element.style.display = 'none';
   }
 
   ngOnDestroy(): void {
@@ -41,12 +46,12 @@ export class SettingsPageComponent implements OnInit, OnDestroy {
   }
 
   open(): void {
-    this.element.style.display == 'block';
+    this.element.style.display = 'block';
     document.body.classList.add('settings-page-open');
   }
 
   close(): void {
-    this.element.style.display == 'none';
+    this.element.style.display = 'none';
     document.body.classList.remove('settings-page-open');
   }
 

--- a/src/app/timer-controls/timer-controls.component.css
+++ b/src/app/timer-controls/timer-controls.component.css
@@ -65,3 +65,8 @@ button.controlBtn:nth-child(3):hover
 {
   background-color: #FFA900;
 }
+
+button.controlBtn:focus {
+  outline-style:dotted;
+  border-radius: 20px;
+}


### PR DESCRIPTION
# Add a settings modal with options to change the functionality of the timer

## Options added:
### User Preferences:
- Timer in tab option
- Browser notification option
- Auto start of timers option

### Sound Options:
- For now this is a WIP until I get more sound files

### Sound volume options:
- Mute
- 25%
- 50%
- 75%
- 100%

### Set Custom Times (in minutes) for the different timers
- Pomodoro timer option
- Short break timer option
- Long break timer option

### Setting Buttons
- Save settings
- Reset settings to base settings
- Sound test 

For now none of these inputs really work and they'll have to get hooked up to the application